### PR TITLE
Add UPNP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 __pycache__
 .vscode
 test-bed.ipynb
+test.py

--- a/client.py
+++ b/client.py
@@ -52,7 +52,6 @@ class Client:
         if not self.broadcast:
             self.broadcast = COMMON_LOCAL_NETWORK_BC
         build_client_banner(remote=self.remote, broadcast=self.broadcast)
-        self.listen()
 
 
 def send_response_packet(preamble: bytes, postamble: bytes, client: Client) -> None:

--- a/input_validation.py
+++ b/input_validation.py
@@ -26,7 +26,7 @@ def validate_server_parameters(args: argparse.Namespace) -> bool:
         if not args.players:
             print("You must specify the players joining the game. Example: --players airmonster.com 1.1.1.1 player.duckdns.com")
             return False
-        
+
         if not validate_players(players=args.players):
             return False
         return True

--- a/lobby_password.py
+++ b/lobby_password.py
@@ -1,11 +1,11 @@
 import base64
-import os
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 import getpass
 import requests
+
 
 def main():
     ip = requests.get('https://api.ipify.org').text.strip()
@@ -32,6 +32,7 @@ def main():
     encrypted_ip = fernet.encrypt(ip.encode('utf-8'))
 
     print("Share this string with other players connecting:", encrypted_ip.decode('utf-8'))
+
 
 if __name__ == '__main__':
     main()

--- a/scct.py
+++ b/scct.py
@@ -9,12 +9,13 @@ def main() -> None:
     try:
         parser: argparse.ArgumentParser = argparse.ArgumentParser(description='SCCTP Server',
                                                                   usage='%(prog)s [options]',
-                                                                  epilog="For more help or information, visit us on discord at https://discord.gg/SC2EXYHA")
+                                                                  epilog="For more help or information, visit us on discord at https://discord.gg/SC2EXYHA\n")
         parser.add_argument('action', type=str, help='The action to perform', choices=['client', 'server'])
         parser.add_argument('--broadcast', type=str, help='Your local broadcast address')
         parser.add_argument('--remote', type=str, help='The external host IP address')
         parser.add_argument('--sip', type=str, help='The source IP address of the host\'s ps2')
         parser.add_argument('--players', type=str, help='Space separated hostnames or IPs of the players joining the game', nargs='+')
+        parser.add_argument('--upnp', action=argparse.BooleanOptionalAction, help='Attempt to use UPnP to open a port on the router')
         args: argparse.Namespace = parser.parse_args()
 
         if args.action == 'client':
@@ -23,7 +24,7 @@ def main() -> None:
 
             remote = args.remote
             broadcast = args.broadcast
-            Client(remote=remote, broadcast=broadcast)
+            Client(remote=remote, broadcast=broadcast).listen()
 
         elif args.action == 'server':
             if not validate_server_parameters(args=args):
@@ -31,7 +32,10 @@ def main() -> None:
 
             local_ps2 = args.sip
             players = args.players
-            Server(local_ps2=local_ps2, players=players)
+            server = Server(local_ps2=local_ps2, players=players)
+            if args.upnp:
+                server.attempt_upnp()
+            server.hole_punch_fw()
 
         else:
             print("Invalid action. Please choose either client or server.")


### PR DESCRIPTION
Closes #4 
For more routers, this probably wont work since the generated upnp request will come from the computer running the script attempting to add an entry for another address. This isnt simple UDP fire and forget, so full MitM would be required for the TCP request to be spoofed. This CAN be done, but leaving it alone for now.